### PR TITLE
ci(dependabot): add npm updates for stable34

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,16 @@ updates:
       time: "03:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Europe/Paris
+    target-branch: stable34
+    open-pull-requests-limit: 10
+    ignore:
+      # do not do breaking changes on stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,18 @@ updates:
       # do not do breaking changes on stable branches
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: composer
+    directories:
+      - "/"
+      - "/vendor-bin/*"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Europe/Paris
+    target-branch: stable34
+    open-pull-requests-limit: 10
+    ignore:
+      # do not do breaking changes on stable branches
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
npm dependencies were only updated on main. Add a patch-only npm update entry for stable34, the only stable branch of this app.

Assisted-by: Claude Code:claude-fable-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
