### PR TITLE
docs: add CSS, component-extraction and testability guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ function name across `src/**/*.spec.ts` before considering the commit
 finished. `npm run test:unit` (see the checklist below) will catch the ones
 you miss, but only if you run it before opening the PR, not after.
 
+Fixing a bug in existing logic — same signature, different behavior — still
+needs a regression test pinning the corrected behavior, in the same commit
+as the fix. Without one, nothing stops the bug from coming back next time
+this code is touched, and the fix reads as untested even in a file that
+already has specs.
+
 A red test means the code is wrong or the behavior it pins changed on
 purpose — never fix it by loosening what it checks. Skipping (`.skip`,
 `.todo`), deleting a case, or dulling a matcher (`toEqual` → `toBeTruthy`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,19 @@ For AI coding agents. Human contributors: see `README.md`.
 git fetch origin && git checkout -b <branch> origin/main
 ```
 
-A stale base fails CI's `npm-build` "Check build changes" job or DCO, and a
-refactor may have moved the code you're about to edit. You'll re-check `main`
-before opening the PR too — see below.
+CI builds your branch merged with current `main`, so a stale base can fail the
+`npm-build` "Check build changes" job even after a recompile, and a refactor
+may have moved the code you're about to edit. You'll re-check `main` before
+opening the PR too — see below.
 
-## One concern per commit, signed off
+## Commit discipline
 
-`git commit -s` — CI enforces DCO. A functional change, a cleanup, and a docs
-update are three commits.
+One concern per commit: a functional change, a cleanup, and a docs update are
+three commits. A reviewer can verify a single-concern diff; a mixed one can
+only be trusted.
+
+CI checks every commit: conventional-format headline (`fix:`, `feat:`,
+`docs:`, ...) and DCO sign-off — `git commit -s`.
 
 Confident AI output still needs splitting: a flawless-looking helper and a real
 bug can come from the same commit.
@@ -30,9 +35,9 @@ git restore --staged js css
 ```
 
 `js/` and `css/` are build output; the `nextcloud-command` bot compiles and
-commits them to your branch after someone comments `/compile` on the PR — say in
-the description that it's still needed. `.githooks/pre-commit` is a backstop,
-not a plan.
+commits them to your branch after a maintainer comments `/compile` on the PR —
+say in the description that it's still needed. `.githooks/pre-commit` is a
+backstop, not a plan.
 
 ## Reuse before you write
 
@@ -75,8 +80,23 @@ Two things follow:
 
 ```bash
 git fetch origin && git log --oneline HEAD..origin/main   # rebase if non-empty
+```
+
+If the change touches `src/` (JS/Vue/CSS):
+
+```bash
 npm run lint
 npm run stylelint
 npm run test:unit
 npm run build   # then unstage js/ css/
+```
+
+If the change touches PHP:
+
+```bash
+composer lint
+composer cs:check
+composer psalm
+composer openapi   # if controllers or routes changed
+                   # commit openapi*.json — unlike js/css, this one is tracked
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,12 @@ CI checks every commit: conventional-format headline (`fix:`, `feat:`,
 A new unit lands with its `.spec.ts` sibling in the same commit —
 `src/utils/` and `src/components/` pair each unit with one; follow that.
 
+Changing what an existing function returns or accepts isn't done until every
+`.spec.ts` that mocks or asserts on it reflects the new shape — `grep` the
+function name across `src/**/*.spec.ts` before considering the commit
+finished. `npm run test:unit` (see the checklist below) will catch the ones
+you miss, but only if you run it before opening the PR, not after.
+
 Confident AI output still needs splitting: a flawless-looking helper and a real
 bug can come from the same commit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ only be trusted.
 CI checks every commit: conventional-format headline (`fix:`, `feat:`,
 `docs:`, ...) and DCO sign-off — `git commit -s`.
 
+A new unit lands with its `.spec.ts` sibling in the same commit —
+`src/utils/` and `src/components/` pair each unit with one; follow that.
+
 Confident AI output still needs splitting: a flawless-looking helper and a real
 bug can come from the same commit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,76 @@
 # Agent instructions
 
-Instructions for AI coding agents (Claude Code and others) working in this repo.
-Human contributors: see `README.md`.
+For AI coding agents. Human contributors: see `README.md`.
 
-## Before starting work
-
-Sync with `origin/main` before branching and again before opening a PR. Branch
-from a stale base and CI's `npm-build` "Check build changes" job, DCO check, or
-plain merge conflicts will fail for reasons unrelated to your change — and a
-refactor may have moved the code you're about to edit somewhere else entirely.
+## Branch from fresh `main`
 
 ```bash
-git fetch origin
-git checkout -b <branch> origin/main
+git fetch origin && git checkout -b <branch> origin/main
 ```
 
-If you've been working for a while, `git fetch origin && git log --oneline
-HEAD..origin/main` before pushing — rebase if `main` has moved.
+A stale base fails CI's `npm-build` "Check build changes" job or DCO, and a
+refactor may have moved the code you're about to edit. You'll re-check `main`
+before opening the PR too — see below.
 
-## Commit atomically
+## One concern per commit, signed off
 
-One concern per commit: a functional change, a cleanup, and a docs update are
-three commits, not one. Do not bundle an unrelated fix into a feature commit
-because it happened to be nearby. A reviewer (human or bot) diffing a single
-concern can actually verify it; a "fix + refactor + docs" commit can't be
-reviewed, only trusted.
+`git commit -s` — CI enforces DCO. A functional change, a cleanup, and a docs
+update are three commits. Confident AI output still needs splitting: a
+flawless-looking helper and a real bug can come from the same commit.
 
-This applies to AI-authored changes as much as human ones. Confident,
-well-commented AI output still needs to be split and verified per concern —
-a flawless-looking helper and a real bug can come from the same commit.
+## Commit source only
 
-## Sign off every commit
+The `nextcloud-command` bot compiles assets via `/compile` on the PR. Build
+locally to test, then hand the tree back clean:
 
-`git commit -s`. DCO is enforced by CI; a missing `Signed-off-by:` trailer
-fails the PR regardless of how correct the change is.
+```bash
+npm run build
+git restore --staged js css
+```
 
-## Never hand-commit build artifacts
+`.githooks/pre-commit` catches staged `js/` or `css/` as a second line of
+defence — unstage them yourself and it never has to fire.
 
-Do not stage or commit changes under `js/` or `css/` — see `README.md`
-("Committing changes") for the full flow. Source only; the `nextcloud-command`
-bot recompiles and commits assets via `/compile` on the PR. `.githooks/pre-commit`
-blocks this locally as a backstop, but don't rely on the hook catching it —
-run `npm run build` for local testing, then `git restore --staged js css`
-(or don't stage them in the first place) before committing.
+## Reuse before you write
 
-## Reuse CSS variables and existing structure
+Preference order: an existing `@nextcloud/vue` component, an existing design
+token, an existing pattern in `src/`. Each keeps you on the design system that
+the library already maintains.
 
-Prefer existing design tokens (`var(--color-...)`, `var(--border-radius)`,
-`var(--default-clickable-area)`, `var(--default-grid-baseline)`, etc.) over
-hardcoded pixel values or colours. Before sizing or styling a new element,
-check how a comparable element elsewhere in `src/` does it, and how the
-`@nextcloud/vue` component it sits next to sizes itself (its compiled CSS is
-under `node_modules/@nextcloud/vue/dist/assets/*.css` — many tokens
-themselves are defined server-side, not in this package, so a grep miss
-there isn't proof no token exists). If you genuinely can't find a matching
-token, use the real value — never invent a `var(--something)` that isn't
-defined anywhere, it silently resolves to nothing.
+Tokens: `var(--color-...)`, `var(--border-radius)`,
+`var(--default-clickable-area)`, `var(--default-grid-baseline)`. Treat
+`node_modules/@nextcloud/vue/dist/assets/*.css` as a partial list — many tokens
+are defined server-side, so search there and assume more exist. Where no token
+matches, use the literal value: an undefined `var()` doesn't fall back to
+anything sensible, the declaration is just dropped.
 
-## Extract components over duplicated template blocks
+## Separate concerns by default
 
-When the same markup — or near-identical markup differing only in
-props/size — appears at multiple call sites *and* a future change (a bug
-fix, a new prop, a behaviour tweak) would need to be applied at every one
-of them to stay correct, extract it into its own component rather than
-copy-pasting. Two call sites can already justify this for UI markup, where
-divergence is easy to introduce by only fixing one copy. Don't extract for
-a single call site, and don't extract just because two blocks currently
-look similar if that similarity is coincidental rather than a shared
-responsibility — that's premature abstraction, not reuse.
+Give each responsibility its own unit. If you can name what a block of markup
+or logic *does* — validates a filename, formats a timestamp, renders a share
+row — that name is the component or function it should become, at one call site
+or five. Prefer small units with explicit inputs (props, arguments) over logic
+inline in a large `<script setup>`; see `src/utils/` and `src/components/` for
+the shape this repo already uses.
 
-Extraction is a refactor. If you're pulling apart duplication that already
-existed before your change, do that as its own commit, separate from the
-functional change that prompted you to notice it (see "Commit atomically"
-above). If the component is new and only exists because of the feature
-you're building, it belongs in that feature's commit — you're not
-separating pre-existing duplication, you're introducing the abstraction as
-part of the change itself.
+Two things follow:
 
-## Prefer existing NC/Vue libraries over hand-rolled markup
+- **Naming is the test — and the bar is a specific, honest name, not just any
+  name.** Almost any block can be given *some* label; that's not the test.
+  If the only name you can find is generic (`handleStuff`, `MiscWrapper.vue`)
+  **or** merely plausible-sounding without actually describing one clear
+  responsibility, the split is along the wrong seam — find the boundary that
+  earns a real name, or leave it inline until one emerges.
+- **Extraction is its own commit** when you're separating duplication or
+  responsibilities that predate your change. A unit that exists only because of
+  the feature you're building belongs in the feature commit.
 
-Check whether `@nextcloud/vue/components` (or another already-installed
-dependency) already covers what you're building before writing raw
-HTML/CSS for it. Hand-rolled UI drifts from the design system over time and
-duplicates maintenance that the library already carries.
+## Before opening a PR
 
-## Structure code so it's easily unit-testable
-
-Prefer small, focused functions/components with explicit inputs (props,
-arguments) over logic buried inline in a large `<script setup>` or template,
-which is often reachable only through a full component mount with heavy
-stubbing — see `src/utils/` and `src/components/` for the pattern this repo
-already uses. But don't extract solely to make something testable: if the
-only caller of the new function or component would be its own test, it
-didn't need extracting. Extract when the logic has a real responsibility of
-its own (validation, formatting, a distinct UI piece) that composes into
-the larger component either way — testability is a side effect of that,
-not the reason for it.
+```bash
+git fetch origin && git log --oneline HEAD..origin/main   # rebase if non-empty
+npm run lint
+npm run stylelint
+npm run test:unit
+npm run build   # then unstage js/ css/
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@ function name across `src/**/*.spec.ts` before considering the commit
 finished. `npm run test:unit` (see the checklist below) will catch the ones
 you miss, but only if you run it before opening the PR, not after.
 
+A red test means the code is wrong or the behavior it pins changed on
+purpose — never fix it by loosening what it checks. Skipping (`.skip`,
+`.todo`), deleting a case, or dulling a matcher (`toEqual` → `toBeTruthy`,
+dropping an assertion) to turn a failure green makes the test stop proving
+anything; it's the bug staying in, with the evidence removed. If behavior
+did change on purpose, update the expectation and say in the commit why the
+new value is correct — not just that it now matches what the code outputs.
+
 Confident AI output still needs splitting: a flawless-looking helper and a real
 bug can come from the same commit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,18 @@ No tokens, secrets, or user file paths in logs or error messages. Render
 user-controlled strings as text, never markup. Psalm findings get fixed, not
 baselined.
 
+## Accessibility is a gate, not polish
+
+Enterprise deployments audit it; regressions block releases.
+
+`@nextcloud/vue` components ship accessible semantics — one more reason
+hand-rolled markup loses. On top of that: every interactive element gets an
+accessible name (icon-only buttons need `aria-label`), state is never colour
+alone, and anything clickable is keyboard-reachable with visible focus.
+
+Nothing enforces this yet — `npm run lint` carries no accessibility rules —
+so check the list above by hand before the PR.
+
 ## Before opening a PR
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,18 @@ as the fix. Without one, nothing stops the bug from coming back next time
 this code is touched, and the fix reads as untested even in a file that
 already has specs.
 
-A red test means the code is wrong or the behavior it pins changed on
-purpose — never fix it by loosening what it checks. Skipping (`.skip`,
-`.todo`), deleting a case, or dulling a matcher (`toEqual` → `toBeTruthy`,
-dropping an assertion) to turn a failure green makes the test stop proving
-anything; it's the bug staying in, with the evidence removed. If behavior
-did change on purpose, update the expectation and say in the commit why the
-new value is correct — not just that it now matches what the code outputs.
+A red test means one of three things: the code is wrong, the behavior it
+pins changed on purpose, or the test itself is wrong — asserting on a mock
+instead of real behavior, or flaky. Only the last two justify touching the
+test, and both require the commit message to say which it is and why, not
+just that the failure went away. Deciding a test is wrong is itself a
+contestable call (see below) — if you're not certain, ask rather than
+deleting the evidence.
+
+Skipping (`.skip`, `.todo`), deleting a case, or dulling a matcher
+(`toEqual` → `toBeTruthy`, dropping an assertion) to turn a failure green
+without that justification makes the test stop proving anything; it's the
+bug staying in, with the evidence removed.
 
 Confident AI output still needs splitting: a flawless-looking helper and a real
 bug can come from the same commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,16 @@ so check the list above by hand before the PR.
 - A new dependency pays its way in bundle size: check what an import drags in
   before adding it.
 
+## When the call is contestable, ask
+
+Two defensible seams from the naming test, a cleanup that would grow the PR,
+a security attribute you can justify but a reviewer might not accept, a
+dependency whose bundle cost is arguable — anywhere a reviewer could
+reasonably want the other option, put the choice to the human driving the
+session before committing to it; unattended, take the narrower option — the
+one that's easier to reverse in review. Either way, flag the call in the PR
+description.
+
 ## Before opening a PR
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,18 @@ Two things follow:
   responsibilities that predate your change. A unit that exists only because of
   the feature you're building belongs in the feature commit.
 
+## Never loosen a security check
+
+Auth here is deliberate: `#[NoAdminRequired]` and `#[NoCSRFRequired]` on a
+controller method are security decisions, not boilerplate — adding one to fix
+a 403 needs a reason a reviewer can check. The same goes for widening a token
+TTL, scope, or validation to make a test or client pass: that is the
+authentication being loosened.
+
+No tokens, secrets, or user file paths in logs or error messages. Render
+user-controlled strings as text, never markup. Psalm findings get fixed, not
+baselined.
+
 ## Before opening a PR
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,52 +15,58 @@ before opening the PR too — see below.
 ## One concern per commit, signed off
 
 `git commit -s` — CI enforces DCO. A functional change, a cleanup, and a docs
-update are three commits. Confident AI output still needs splitting: a
-flawless-looking helper and a real bug can come from the same commit.
+update are three commits.
+
+Confident AI output still needs splitting: a flawless-looking helper and a real
+bug can come from the same commit.
 
 ## Commit source only
 
-The `nextcloud-command` bot compiles assets via `/compile` on the PR. Build
-locally to test, then hand the tree back clean:
+Build locally to test, then hand the tree back clean:
 
 ```bash
 npm run build
 git restore --staged js css
 ```
 
-`.githooks/pre-commit` catches staged `js/` or `css/` as a second line of
-defence — unstage them yourself and it never has to fire.
+`js/` and `css/` are build output; the `nextcloud-command` bot compiles and
+commits them to your branch after someone comments `/compile` on the PR — say in
+the description that it's still needed. `.githooks/pre-commit` is a backstop,
+not a plan.
 
 ## Reuse before you write
 
 Preference order: an existing `@nextcloud/vue` component, an existing design
-token, an existing pattern in `src/`. Each keeps you on the design system that
-the library already maintains.
+token, an existing pattern in `src/`.
+
+Each keeps you on the design system the library already maintains; hand-rolled
+equivalents drift from it and duplicate maintenance.
 
 Tokens: `var(--color-...)`, `var(--border-radius)`,
 `var(--default-clickable-area)`, `var(--default-grid-baseline)`. Treat
 `node_modules/@nextcloud/vue/dist/assets/*.css` as a partial list — many tokens
 are defined server-side, so search there and assume more exist. Where no token
-matches, use the literal value: an undefined `var()` doesn't fall back to
-anything sensible, the declaration is just dropped.
+matches, use the literal value.
+
+An undefined `var()` doesn't fall back to an earlier declaration in the same
+rule — the property resets to its inherited or initial value, so a hardcoded
+line above the token is not a safety net.
 
 ## Separate concerns by default
 
-Give each responsibility its own unit. If you can name what a block of markup
-or logic *does* — validates a filename, formats a timestamp, renders a share
-row — that name is the component or function it should become, at one call site
-or five. Prefer small units with explicit inputs (props, arguments) over logic
+Give each responsibility its own unit. If you can name what a block of markup or
+logic *does* — validates a filename, formats a timestamp, renders a share row —
+that name is the component or function it should become, at one call site or
+five. Prefer small units with explicit inputs (props, arguments) over logic
 inline in a large `<script setup>`; see `src/utils/` and `src/components/` for
 the shape this repo already uses.
 
 Two things follow:
 
-- **Naming is the test — and the bar is a specific, honest name, not just any
-  name.** Almost any block can be given *some* label; that's not the test.
-  If the only name you can find is generic (`handleStuff`, `MiscWrapper.vue`)
-  **or** merely plausible-sounding without actually describing one clear
-  responsibility, the split is along the wrong seam — find the boundary that
-  earns a real name, or leave it inline until one emerges.
+- **Naming is the test.** The name has to be specific and honest: if the best
+  you can find is `handleStuff` or `MiscWrapper.vue`, or the accurate name needs
+  an "and" in it, the seam is wrong. Find the boundary that earns a real name,
+  or leave it inline until one emerges.
 - **Extraction is its own commit** when you're separating duplication or
   responsibilities that predate your change. A unit that exists only because of
   the feature you're building belongs in the feature commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,56 @@ bot recompiles and commits assets via `/compile` on the PR. `.githooks/pre-commi
 blocks this locally as a backstop, but don't rely on the hook catching it —
 run `npm run build` for local testing, then `git restore --staged js css`
 (or don't stage them in the first place) before committing.
+
+## Reuse CSS variables and existing structure
+
+Prefer existing design tokens (`var(--color-...)`, `var(--border-radius)`,
+`var(--default-clickable-area)`, `var(--default-grid-baseline)`, etc.) over
+hardcoded pixel values or colours. Before sizing or styling a new element,
+check how a comparable element elsewhere in `src/` does it, and how the
+`@nextcloud/vue` component it sits next to sizes itself (its compiled CSS is
+under `node_modules/@nextcloud/vue/dist/assets/*.css` — many tokens
+themselves are defined server-side, not in this package, so a grep miss
+there isn't proof no token exists). If you genuinely can't find a matching
+token, use the real value — never invent a `var(--something)` that isn't
+defined anywhere, it silently resolves to nothing.
+
+## Extract components over duplicated template blocks
+
+When the same markup — or near-identical markup differing only in
+props/size — appears at multiple call sites *and* a future change (a bug
+fix, a new prop, a behaviour tweak) would need to be applied at every one
+of them to stay correct, extract it into its own component rather than
+copy-pasting. Two call sites can already justify this for UI markup, where
+divergence is easy to introduce by only fixing one copy. Don't extract for
+a single call site, and don't extract just because two blocks currently
+look similar if that similarity is coincidental rather than a shared
+responsibility — that's premature abstraction, not reuse.
+
+Extraction is a refactor. If you're pulling apart duplication that already
+existed before your change, do that as its own commit, separate from the
+functional change that prompted you to notice it (see "Commit atomically"
+above). If the component is new and only exists because of the feature
+you're building, it belongs in that feature's commit — you're not
+separating pre-existing duplication, you're introducing the abstraction as
+part of the change itself.
+
+## Prefer existing NC/Vue libraries over hand-rolled markup
+
+Check whether `@nextcloud/vue/components` (or another already-installed
+dependency) already covers what you're building before writing raw
+HTML/CSS for it. Hand-rolled UI drifts from the design system over time and
+duplicates maintenance that the library already carries.
+
+## Structure code so it's easily unit-testable
+
+Prefer small, focused functions/components with explicit inputs (props,
+arguments) over logic buried inline in a large `<script setup>` or template,
+which is often reachable only through a full component mount with heavy
+stubbing — see `src/utils/` and `src/components/` for the pattern this repo
+already uses. But don't extract solely to make something testable: if the
+only caller of the new function or component would be its own test, it
+didn't need extracting. Extract when the logic has a real responsibility of
+its own (validation, formatting, a distinct UI piece) that composes into
+the larger component either way — testability is a side effect of that,
+not the reason for it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,17 @@ alone, and anything clickable is keyboard-reachable with visible focus.
 Nothing enforces this yet — `npm run lint` carries no accessibility rules —
 so check the list above by hand before the PR.
 
+## Bound work and memory
+
+- No unbounded reads: cap or paginate anything that grows with a user's file
+  count, in queries and in rendered rows.
+- Release what you register: listeners, timers, and observers added in a
+  component are removed in `onUnmounted` — see `TemplateSection.vue`.
+- Stream file contents; never read a whole document into memory — office
+  files have no upper size.
+- A new dependency pays its way in bundle size: check what an import drags in
+  before adding it.
+
 ## Before opening a PR
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ If the change touches PHP:
 composer lint
 composer cs:check
 composer psalm
+composer test:unit
 composer openapi   # if controllers or routes changed
                    # commit openapi*.json — unlike js/css, this one is tracked
 ```


### PR DESCRIPTION
## Summary
Follow-up to #84. Adds four rules to `AGENTS.md` covering what came up while redoing #79 and #83 this session:

- **Reuse CSS variables and existing structure** — prefer design tokens over hardcoded pixel/colour values; check a comparable component's compiled CSS or `src/` usage before hardcoding, and never invent a `var()` that isn't defined anywhere.
- **Extract components over duplicated template blocks** — only for genuine multi-site duplication where a future change would need applying everywhere to stay correct, not surface-level similarity. Scoped as its own commit when pulling apart pre-existing duplication (per "Commit atomically"), unless the component is new to the feature being built.
- **Prefer existing NC/Vue libraries over hand-rolled markup** — check `@nextcloud/vue/components` before writing raw HTML/CSS.
- **Structure code so it's easily unit-testable** — small, focused functions/components with explicit inputs, but not extracted solely to reach a test.

This draft went through an internal adversarial review pass before being finalized — it caught and fixed a contradiction with the atomic-commits rule, a too-loose "two call sites" abstraction threshold, a missing test-induced-extraction caveat, and a fragile/unguarded CSS-token-lookup instruction. All four are addressed in the wording above.

## Test plan
- [ ] N/A — docs only, no code paths affected