### PR TITLE
docs: Backfill CHANGELOG.md from merged PR history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- First release
+- Office overview page — browse, filter, search, and create Documents,
+  Spreadsheets, Presentations, and Diagrams from a single page (#5)
+
+### Changed
+
+- Updated app icon to Material Symbols (#108)
+
+### Fixed
+
+- Search now covers all Office file types, not just a subset (#15)
+- Exclude external storage from the "Mine" filter (#48)
+- Sort recent files newest-first (#85)
+- Order and limit the DAV search so "Recent" is actually recent (#105)
+
+### Security
+
+- Address npm audit findings in dependencies (#24, #26, #31, #41)


### PR DESCRIPTION
\`CHANGELOG.md\` has read \`## [Unreleased] / Added / First release\` since the initial skeleton commit — every merge since (overview page, search fixes, npm audit fixes, icon update) went unrecorded.

Backfilled from the merged, non-Dependabot PR history against \`main\`, grouped by Keep a Changelog category. Internal-only work (ci/docs/test/chore, l10n tooling) is left out — this file is for consumers, not contributors.

Kept everything under \`[Unreleased]\` — nothing's shipped through a versioned channel yet, so there's no real "previous release" to close out. The header should only flip to \`## [1.1.0] - <date>\` once \`appinfo/info.xml\` drops the \`-dev\` suffix from #110 (mirroring \`text\`'s own \`X.Y.Z-dev.N\` → \`X.Y.Z\` pattern).

Closes #109